### PR TITLE
Add "last 24 hours" alias

### DIFF
--- a/src/seen.coffee
+++ b/src/seen.coffee
@@ -73,7 +73,7 @@ module.exports = (robot) ->
       seen.add (ircname msg), (ircchan msg)
 
   robot.respond /seen @?([-\w.\\^|{}`\[\]]+):? ?(.*)/, (msg) ->
-    if msg.match[1] == "in" and msg.match[2] == "last 24h"
+    if msg.match[1] == "in" and (msg.match[2] == "last 24h" or msg.match[2] == "last 24 hours")
       users = seen.usersSince(24)
       msg.send "Active in #{msg.match[2]}: #{users.join(', ')}"
     else


### PR DESCRIPTION
This adds an "seen in last 24 hours" as an alias to "seen in last 24h." Why? Because nobody in my Slack can get it right.

This doesn't 100% solve the problem because there are about a million ways to try to invoke this command in the wrong way, but this at least increases the odds of getting it right.

![screen shot 2016-10-23 at 2 02 50 am](https://cloud.githubusercontent.com/assets/532647/19624843/0afbe852-98c5-11e6-8a5c-d8bd9e37865a.png)

Note: Not 100% correct on the CoffeeScript syntax for this kind of logic operator, but I'm 99% sure it works.

Note 2: I know this is a `hubot-scripts` org repo. Are these still maintained or is this supposed to be forked off and maintained independently?
