### PR TITLE
Default to showing relative times

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then add **hubot-seen** to your `external-scripts.json`:
 
 ## Configuration
 
-Set `HUBOT_SEEN_NORELATIVE` in the environment to output an absolute time (like "Sat Feb 11 2017 03:12:39 GMT-0500 (EST)") instead of a relative one (like "less than a minute ago").
+Set `HUBOT_SEEN_TIMEAGO` to `false` in the environment to output an absolute time (like "Sat Feb 11 2017 03:12:39 GMT-0500 (EST)") instead of a relative one (like "less than a minute ago"). Defaults to true (i.e. relative times).
 
 ## Sample Interaction
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ Then add **hubot-seen** to your `external-scripts.json`:
 ["hubot-seen"]
 ```
 
+## Configuration
+
+Set `HUBOT_SEEN_NORELATIVE` in the environment to output an absolute time (like "Sat Feb 11 2017 03:12:39 GMT-0500 (EST)") instead of a relative one (like "less than a minute ago").
+
 ## Sample Interaction
 
 ```
 user1>> hubot seen wiredfool
-hubot>> wiredfool was last seen in #joiito on <date>
+hubot>> wiredfool was last seen in #joiito less than a minute ago
 
 ```

--- a/src/seen.coffee
+++ b/src/seen.coffee
@@ -6,13 +6,13 @@
 #   hubot seen in last 24h - list users seen in last 24 hours
 #
 # Configuration:
-#   HUBOT_SEEN_NORELATIVE - If set (to anything), last seen times will be absolute dates instead of relative
+#   HUBOT_SEEN_TIMEAGO - If set to `false` (defaults to `true`), last seen times will be absolute dates instead of relative
 #
 # Author:
 #   wiredfool, patcon@gittip
 
 config =
-  absolute_times: process.env.HUBOT_SEEN_NORELATIVE
+  use_timeago: process.env.HUBOT_SEEN_TIMEAGO isnt 'false'
 
 clean = (thing) ->
   (thing || '').toLowerCase().trim()
@@ -82,7 +82,7 @@ module.exports = (robot) ->
       nick = msg.match[1]
       last = seen.last nick
       if last.date
-        date_string = unless config.absolute_times?
+        date_string = if config.use_timeago
           timeago = require 'timeago'
           timeago(new Date(last.date))
         else

--- a/src/seen.coffee
+++ b/src/seen.coffee
@@ -6,13 +6,13 @@
 #   hubot seen in last 24h - list users seen in last 24 hours
 #
 # Configuration:
-#   HUBOT_SEEN_TIMEAGO - If set (to anything), last seen times will be relative
+#   HUBOT_SEEN_NORELATIVE - If set (to anything), last seen times will be absolute dates instead of relative
 #
 # Author:
 #   wiredfool, patcon@gittip
 
 config =
-  use_timeago: process.env.HUBOT_SEEN_TIMEAGO
+  absolute_times: process.env.HUBOT_SEEN_NORELATIVE
 
 clean = (thing) ->
   (thing || '').toLowerCase().trim()
@@ -82,7 +82,7 @@ module.exports = (robot) ->
       nick = msg.match[1]
       last = seen.last nick
       if last.date
-        date_string = if config.use_timeago?
+        date_string = unless config.absolute_times?
           timeago = require 'timeago'
           timeago(new Date(last.date))
         else


### PR DESCRIPTION
So I went to fix #14 and it turns out this is already present in the codebase. However, I still think that way is much more useful, so I switched the default and documented how to get the old behavior back.

Obviously this is semver-major, but since #12 hasn't happened yet it doesn't really matter.